### PR TITLE
added isHttps variable to RequestUrl

### DIFF
--- a/TechDevils.UrlTaskScheduler/TechDevilsTaskScheduler/Service/Interfaces/IUrlRequestService.cs
+++ b/TechDevils.UrlTaskScheduler/TechDevilsTaskScheduler/Service/Interfaces/IUrlRequestService.cs
@@ -4,6 +4,6 @@ namespace TechDevils.UrlTaskScheduler.TechDevilsTaskScheduler.Service.Interfaces
 {
     public interface IUrlRequestService
     {
-        int RequestUrl(string url, int id, bool returnResult = false);
+        int RequestUrl(bool isHttps, string url, int id, bool returnResult = false);
     }
 }

--- a/TechDevils.UrlTaskScheduler/TechDevilsTaskScheduler/Service/UrlRequestService.cs
+++ b/TechDevils.UrlTaskScheduler/TechDevilsTaskScheduler/Service/UrlRequestService.cs
@@ -21,14 +21,14 @@ namespace TechDevils.UrlTaskScheduler.TechDevilsTaskScheduler.Service
             log = LogManager.GetLogger(typeof (UrlRequestService));
         }
 
-        public int RequestUrl(string url, int id, bool returnResult = false)
+        public int RequestUrl(bool isHttps, string url, int id, bool returnResult = false)
         {
             var status = 0;
 
             try
             {
                 //ToDo : Sort http out so that it picks the right url check for relative paths
-                var webRequest = (HttpWebRequest) WebRequest.Create("http://"+url);
+                var webRequest = (HttpWebRequest) WebRequest.Create((isHttps ? "https://" : "http://") + url);
 
                 var httpWebResponse = webRequest.GetResponse();
 

--- a/TechDevils.UrlTaskScheduler/TechDevilsTaskScheduler/Service/UrlRunningService.cs
+++ b/TechDevils.UrlTaskScheduler/TechDevilsTaskScheduler/Service/UrlRunningService.cs
@@ -110,7 +110,7 @@ namespace TechDevils.UrlTaskScheduler.TechDevilsTaskScheduler.Service
 
             _database.CompleteTransaction();
 
-            return _requestService.RequestUrl(url.Url, url.Id);
+            return _requestService.RequestUrl(url.IsHttps, url.Url, url.Id);
         }
 
         private void SetRunningStatus(ScheduleUrl record)


### PR DESCRIPTION
The https option from the UrlScheduler dashboard was not used in the code. The RequestUrl method was adding "http://" in all cases. I have used this package previously, and didn't have an issue, but it wasn't working for me this time. I think it is something to do with rewrite rules. Anyway, it adds the right protocol now and seems to work fine. I am not sure if this project is maintained anymore, but here is this little pull request for you to review if so.
Thanks for the package.